### PR TITLE
Handle missing width and height attributes.

### DIFF
--- a/svg_stack.py
+++ b/svg_stack.py
@@ -178,8 +178,16 @@ class SVGFileBase(object):
         if self._root.tag != '{http://www.w3.org/2000/svg}svg':
             raise ValueError('expected file to have root element <svg:svg>')
 
-        height, height_units = get_unit_attr(self._root.get('height'))
-        width, width_units = get_unit_attr(self._root.get('width'))
+        if 'height' in self._root.keys():
+            height, height_units = get_unit_attr(self._root.get('height'))
+            width, width_units = get_unit_attr(self._root.get('width'))
+        else:
+            # R svglite does not set the height and width attributes. Get them from the viewBox attribute.
+            vbox = self._root.get('viewBox')
+            _, _, width, height = vbox.split(' ')
+            width =  float(width)
+            height = float(height)
+            width_units = height_units = 'px' # The default
         self._width_px = convert_to_pixels( width, width_units)
         self._height_px = convert_to_pixels( height, height_units)
         self._orig_width_px = self._width_px


### PR DESCRIPTION
Some sources, including svglite for R, don't set the width and height attributes (see https://github.com/r-lib/svglite/issues/12).
In at least some of these cases, we can extract these properties from the viewBox attribute instead.